### PR TITLE
serval fixes

### DIFF
--- a/http2/tornado2.py
+++ b/http2/tornado2.py
@@ -425,7 +425,6 @@ class _SSLIOStream(iostream.SSLIOStream):
 class _HTTP2ConnectionFactory(object):
     def __init__(self, io_loop, host, port, max_buffer_size,
                  secure=True, cert_options=None, connect_timeout=None):
-        self.start_time = time.time()
         self.io_loop = io_loop
         self.max_buffer_size = max_buffer_size
         self.cert_options = collections.defaultdict(lambda: None, **cert_options or {})
@@ -458,7 +457,7 @@ class _HTTP2ConnectionFactory(object):
                 self._on_connect(_stream, ready_callback, close_callback)
 
             timeout_handle = self.io_loop.add_timeout(
-                self.start_time + self.connect_timeout, _on_timeout)
+                start_time + self.connect_timeout, _on_timeout)
 
         else:
             _on_connect = functools.partial(

--- a/http2/tornado2.py
+++ b/http2/tornado2.py
@@ -188,8 +188,8 @@ class SimpleAsyncHTTPClientWithTimeout(simple_httpclient.SimpleAsyncHTTPClient):
 
         if not len(self.active) < self.max_clients:
             timeout_handle = self.io_loop.add_timeout(
-                self.io_loop.time() + min(request.connect_timeout,
-                                          request.request_timeout),
+                time.time() + min(request.connect_timeout,
+                                  request.request_timeout),
                 functools.partial(self._on_timeout, key))
         else:
             timeout_handle = None
@@ -215,7 +215,7 @@ class SimpleAsyncHTTPClientWithTimeout(simple_httpclient.SimpleAsyncHTTPClient):
         self.queue.remove((key, request, callback))
         timeout_response = HTTPResponse(
             request, 599, error=HTTPError(599, "Timeout"),
-            request_time=self.io_loop.time() - request.start_time)
+            request_time=time.time() - request.start_time)
         self.io_loop.add_callback(callback, timeout_response)
         del self.waiting[key]
 

--- a/http2/tornado2.py
+++ b/http2/tornado2.py
@@ -613,8 +613,11 @@ class _HTTP2ConnectionContext(object):
                     with stack_context.ExceptionStackContext(stream_delegate.handle_exception):
                         stream_delegate.handle_event(event)
                 else:
-                    self.reset_stream(stream_id)
-                    logger.warning('unexpected stream: %s, event: %r', stream_id, event)
+                    # FIXME: our nginx server will simply reset stream,
+                    # without increase the window size which consumed by
+                    # queued data frame which was belongs to the stream we're resetting
+                    # self.reset_stream(stream_id)
+                    logger.info('Unexpected stream: %s, event: %r', stream_id, event)
 
                 continue
 
@@ -931,8 +934,10 @@ class _HTTP2Stream(object):
         if hasattr(self, 'stream_id'):
             self.context.remove_stream_delegate(self.stream_id)
 
-            # TODO: should we reset & flush immediately?
-            self.context.reset_stream(self.stream_id, flush=True)
+            # FIXME: our nginx server will simply reset stream,
+            # without increase the window size which consumed by
+            # queued data frame which was belongs to the stream we're resetting
+            # self.context.reset_stream(self.stream_id, flush=True)
 
         response = HTTP2Response(
             self.request, 599, error=error,

--- a/http2/tornado2.py
+++ b/http2/tornado2.py
@@ -427,7 +427,7 @@ class _HTTP2ConnectionFactory(object):
 
     @classmethod
     def _handle_exception(cls, close_callback, typ, value, tb):
-        close_callback(None, value)
+        close_callback(io_stream=None, reason=value)
         return True
 
     @classmethod

--- a/http2/tornado2.py
+++ b/http2/tornado2.py
@@ -757,8 +757,7 @@ class _HTTP2Stream(object):
         with stack_context.ExceptionStackContext(self.handle_exception):
             if request.request_timeout:
                 self._timeout = self.io_loop.add_timeout(
-                    self.start_time + request.request_timeout,
-                    stack_context.wrap(self._on_timeout))
+                    self.start_time + request.request_timeout, self._on_timeout)
 
             if stream_id is None:
                 self.request = self.prepare_request(request, default_host)

--- a/http2/tornado2.py
+++ b/http2/tornado2.py
@@ -466,6 +466,7 @@ class _HTTP2ConnectionFactory(object):
                 close_callback=close_callback,
             )
 
+        logger.info('Establishing HTTP/2 connection to %s:%s...', self.host, self.port)
         with stack_context.ExceptionStackContext(
                 functools.partial(self._handle_exception, close_callback)):
 

--- a/http2/tornado2.py
+++ b/http2/tornado2.py
@@ -169,6 +169,7 @@ class GzipDecompressor(object):
 
 class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
     MAX_CONNECTION_BACKOFF = 10
+    CONNECTION_BACKOFF_STEP = 1
     CLIENT_REGISTRY = {}
 
     def __new__(cls, *args, **kwargs):
@@ -202,13 +203,13 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
             cert_options=cert_options,
         )
 
-        # back-off
-        self.connection_backoff = 0
-        self.next_connect_time = 0
-
         # open connection
         self.connection = None
         self.io_stream = None
+
+        # back-off
+        self.next_connect_time = 0
+        self.connection_backoff = self.CONNECTION_BACKOFF_STEP
 
         self.connection_factory.make_connection(
             self._on_connection_ready, self._on_connection_close)
@@ -233,12 +234,14 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
             connection.on_connection_close(io_stream.error)
 
         # schedule back-off
-        self.connection_backoff = min(
-            self.connection_backoff + 1, self.MAX_CONNECTION_BACKOFF)
         now_time = time.time()
         self.next_connect_time = max(
             self.next_connect_time,
             now_time + self.connection_backoff)
+
+        self.connection_backoff = min(
+            self.connection_backoff + self.CONNECTION_BACKOFF_STEP,
+            self.MAX_CONNECTION_BACKOFF)
 
         if io_stream is None:
             logger.info(
@@ -266,8 +269,8 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
             self.io_stream, 'Server requested, code: 0x%x' % event.error_code)
 
     def _on_connection_ready(self, io_stream):
-        # reset back-off
-        self.next_connect_time = max(time.time(), self.next_connect_time)
+        # reset back-off, prevent reconnect within back-off period
+        self.next_connect_time += self.connection_backoff
         self.connection_backoff = 0
 
         self.io_stream = io_stream

--- a/http2/tornado2.py
+++ b/http2/tornado2.py
@@ -186,23 +186,25 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
     def initialize(self, io_loop, host, port=None, max_streams=200,
                    hostname_mapping=None, max_buffer_size=104857600,
                    resolver=None, defaults=None, secure=True,
-                   cert_options=None, enable_push=False,
+                   cert_options=None, enable_push=False, connect_timeout=20,
                    initial_window_size=65535, **conn_kwargs):
         # initially, we disables stream multiplexing and wait the settings frame
         super(SimpleAsyncHTTP2Client, self).initialize(
             io_loop=io_loop, max_clients=1,
             hostname_mapping=hostname_mapping, max_buffer_size=max_buffer_size,
         )
-        self.max_streams = max_streams
         self.host = host
         self.port = port
         self.secure = secure
+        self.max_streams = max_streams
         self.enable_push = bool(enable_push)
         self.initial_window_size = initial_window_size
+
+        self.connect_timeout = connect_timeout
         self.connection_factory = _HTTP2ConnectionFactory(
             io_loop=self.io_loop, host=host, port=port,
             max_buffer_size=self.max_buffer_size, secure=secure,
-            cert_options=cert_options,
+            cert_options=cert_options, connect_timeout=self.connect_timeout
         )
 
         # open connection

--- a/http2/tornado2.py
+++ b/http2/tornado2.py
@@ -186,7 +186,8 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
     def initialize(self, io_loop, host, port=None, max_streams=200,
                    hostname_mapping=None, max_buffer_size=104857600,
                    resolver=None, defaults=None, secure=True,
-                   cert_options=None, enable_push=False, **conn_kwargs):
+                   cert_options=None, enable_push=False,
+                   initial_window_size=65535, **conn_kwargs):
         # initially, we disables stream multiplexing and wait the settings frame
         super(SimpleAsyncHTTP2Client, self).initialize(
             io_loop=io_loop, max_clients=1,
@@ -196,7 +197,8 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
         self.host = host
         self.port = port
         self.secure = secure
-        self.enable_push = enable_push
+        self.enable_push = bool(enable_push)
+        self.initial_window_size = initial_window_size
         self.connection_factory = _HTTP2ConnectionFactory(
             io_loop=self.io_loop, host=host, port=port,
             max_buffer_size=self.max_buffer_size, secure=secure,
@@ -278,6 +280,7 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
             io_stream=io_stream, secure=self.secure,
             enable_push=self.enable_push,
             max_buffer_size=self.max_buffer_size,
+            initial_window_size=self.initial_window_size,
         )
         self.connection.add_event_handler(
             h2.events.RemoteSettingsChanged, self._adjust_settings
@@ -488,10 +491,12 @@ class _HTTP2ConnectionFactory(object):
 class _HTTP2ConnectionContext(object):
     """maintenance a http/2 connection state on specific io_stream
     """
-    def __init__(self, io_stream, secure, enable_push, max_buffer_size):
+    def __init__(self, io_stream, secure, enable_push,
+                 max_buffer_size, initial_window_size):
         self.io_stream = io_stream
         self.schema = 'https' if secure else 'http'
-        self.enable_push = bool(enable_push)
+        self.enable_push = enable_push
+        self.initial_window_size = initial_window_size
         self.max_buffer_size = max_buffer_size
         self.is_closed = False
 
@@ -502,6 +507,7 @@ class _HTTP2ConnectionContext(object):
         self.h2_conn.initiate_connection()
         self.h2_conn.update_settings({
             h2.settings.ENABLE_PUSH: int(self.enable_push),
+            h2.settings.INITIAL_WINDOW_SIZE: self.initial_window_size,
         })
 
         self._setup_reading()

--- a/http2/tornado4.py
+++ b/http2/tornado4.py
@@ -303,6 +303,7 @@ class _HTTP2ConnectionContext(object):
         # h2 contexts
         self.stream_delegates = {}
         self.event_handlers = {}  # connection level event, event -> handler
+        self.reset_stream_ids = collections.deque(maxlen=50)
         self.h2_conn = h2.connection.H2Connection(client_side=True)
         self.h2_conn.initiate_connection()
         self.h2_conn.update_settings({
@@ -417,7 +418,11 @@ class _HTTP2ConnectionContext(object):
                     # without increase the window size which consumed by
                     # queued data frame which was belongs to the stream we're resetting
                     # self.reset_stream(stream_id)
-                    logger.info('Unexpected stream: %s, event: %r', stream_id, event)
+                    if stream_id in self.reset_stream_ids:
+                        if isinstance(event, h2.events.StreamEnded):
+                            self.reset_stream_ids.remove(stream_id)
+                    else:
+                        logger.warning('Unexpected stream: %s, event: %r', stream_id, event)
 
                 continue
 
@@ -736,6 +741,7 @@ class _HTTP2Stream(httputil.HTTPMessageDelegate):
             # without increase the window size which consumed by
             # queued data frame which was belongs to the stream we're resetting
             # self.context.reset_stream(self.stream_id, flush=True)
+            self.context.reset_stream_ids.append(self.stream_id)
 
         error.__traceback__ = tb
         response = HTTP2Response(

--- a/http2/tornado4.py
+++ b/http2/tornado4.py
@@ -256,7 +256,7 @@ class _HTTP2ConnectionFactory(object):
 
     @classmethod
     def _handle_exception(cls, close_callback, typ, value, tb):
-        close_callback(None, value)
+        close_callback(io_stream=None, reason=value)
         return True
 
     @classmethod

--- a/http2/tornado4.py
+++ b/http2/tornado4.py
@@ -413,8 +413,11 @@ class _HTTP2ConnectionContext(object):
                     with stack_context.ExceptionStackContext(stream_delegate.handle_exception):
                         stream_delegate.handle_event(event)
                 else:
-                    self.reset_stream(stream_id)
-                    logger.warning('unexpected stream: %s, event: %r', stream_id, event)
+                    # FIXME: our nginx server will simply reset stream,
+                    # without increase the window size which consumed by
+                    # queued data frame which was belongs to the stream we're resetting
+                    # self.reset_stream(stream_id)
+                    logger.info('Unexpected stream: %s, event: %r', stream_id, event)
 
                 continue
 
@@ -729,8 +732,10 @@ class _HTTP2Stream(httputil.HTTPMessageDelegate):
         if hasattr(self, 'stream_id'):
             self.context.remove_stream_delegate(self.stream_id)
 
-            # TODO: should we reset & flush immediately?
-            self.context.reset_stream(self.stream_id, flush=True)
+            # FIXME: our nginx server will simply reset stream,
+            # without increase the window size which consumed by
+            # queued data frame which was belongs to the stream we're resetting
+            # self.context.reset_stream(self.stream_id, flush=True)
 
         error.__traceback__ = tb
         response = HTTP2Response(

--- a/http2/tornado4.py
+++ b/http2/tornado4.py
@@ -82,7 +82,7 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
     def initialize(self, io_loop, host, port=None, max_streams=200,
                    hostname_mapping=None, max_buffer_size=104857600,
                    resolver=None, defaults=None, secure=True,
-                   cert_options=None, enable_push=False,
+                   cert_options=None, enable_push=False, connect_timeout=20,
                    initial_window_size=65535, **conn_kwargs):
         # initially, we disables stream multiplexing and wait the settings frame
         super(SimpleAsyncHTTP2Client, self).initialize(
@@ -90,16 +90,19 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
             hostname_mapping=hostname_mapping, max_buffer_size=max_buffer_size,
             resolver=resolver, defaults=defaults, max_header_size=None,
         )
-        self.max_streams = max_streams
         self.host = host
         self.port = port
         self.secure = secure
+        self.max_streams = max_streams
         self.enable_push = bool(enable_push)
         self.initial_window_size = initial_window_size
+
+        self.connect_timeout = connect_timeout
         self.connection_factory = _HTTP2ConnectionFactory(
             io_loop=self.io_loop, host=host, port=port,
             max_buffer_size=self.max_buffer_size, secure=secure,
             tcp_client=self.tcp_client, cert_options=cert_options,
+            connect_timeout=self.connect_timeout,
         )
 
         # open connection

--- a/http2/tornado4.py
+++ b/http2/tornado4.py
@@ -246,6 +246,7 @@ class _HTTP2ConnectionFactory(object):
                 close_callback=close_callback,
             )
 
+        logger.info('Establishing HTTP/2 connection to %s:%s...', self.host, self.port)
         with stack_context.ExceptionStackContext(
                 functools.partial(self._handle_exception, close_callback)):
             self.tcp_client.connect(

--- a/http2/tornado4.py
+++ b/http2/tornado4.py
@@ -206,7 +206,6 @@ class SimpleAsyncHTTP2Client(simple_httpclient.SimpleAsyncHTTPClient):
 class _HTTP2ConnectionFactory(object):
     def __init__(self, io_loop, host, port, max_buffer_size, tcp_client,
                  secure=True, cert_options=None, connect_timeout=None):
-        self.start_time = time.time()
         self.io_loop = io_loop
         self.max_buffer_size = max_buffer_size
         self.tcp_client = tcp_client
@@ -239,8 +238,7 @@ class _HTTP2ConnectionFactory(object):
                 self._on_connect(io_stream, ready_callback, close_callback)
 
             timeout_handle = self.io_loop.add_timeout(
-                self.start_time + self.connect_timeout,
-                stack_context.wrap(_on_timeout))
+                start_time + self.connect_timeout, _on_timeout)
 
         else:
             _on_connect = functools.partial(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-h2>=2.1.0
+h2>=2.4.0
 tornado>=2.4.1
 certifi
 backports.ssl_match_hostname

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'http2': 'http2',
     },
     install_requires=[
-        'h2>=2.1.0',
+        'h2>=2.4.0',
         'tornado>=2.4.1',
         'backports.ssl_match_hostname',
     ],


### PR DESCRIPTION
1. fix back-off logic
2. allow to setup initial_window_size of h2 connection
3. upgrade h2 to version==2.4.0
4. [nginx quirks] don't reset stream immediately... and never reset a stream
5. hide unnecessary logs for reset streams
6. allow indicate connect_timeout, defaults to 20s
7. add timeout support for tornado2's SimpleAsyncHTTPClient
8. [tornado4] use self.io_loop.time() instead of time.time()
9. add connection log
10. minor fixes
